### PR TITLE
Allow developers to define credentials_file path if needed

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -13,7 +13,7 @@ class Configuration
     /**
      * @var string
      */
-    public $CredentialsFile = '../lib/promisepay-credentials.xml';
+    public static $CredentialsFile = '../lib/promisepay-credentials.xml';
 
     /**
      *
@@ -29,13 +29,13 @@ class Configuration
      */
     private function _loadDataFromCredentials($data)
     {
-        if(file_exists($this->CredentialsFile))
+        if(file_exists(self::$CredentialsFile))
         {
-            return (string)simplexml_load_file($this->CredentialsFile)->$data;
+            return (string)simplexml_load_file(self::$CredentialsFile)->$data;
         }
         else
         {
-            throw new Exception\Credentials($this->CredentialsFile.' not found!');
+            throw new Exception\Credentials(self::$CredentialsFile.' not found!');
         }
     }
 


### PR DESCRIPTION
Developer can simply redefine path to credentials file using next line PromisePay\Configuration::$CredentialsFile = "../../../something-else.xml";