### PR TITLE
Allow relative paths for the credentials XML File

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -29,16 +29,24 @@ class Configuration
      */
     private function _loadDataFromCredentials($data)
     {
-        if(file_exists(__DIR__ . self::$CredentialsFile))
+        $filepath = self::$CredentialsFile;
+
+        // check for relative paths
+        if (! file_exists($filepath))
         {
-            return (string)simplexml_load_file(__DIR__ . self::$CredentialsFile)->$data;
+            $filepath = __DIR__ . $filepath;
+        }
+
+        if(file_exists($filepath))
+        {
+            return (string)simplexml_load_file($filepath)->$data;
         }
         else
         {
-            throw new Exception\Credentials(__DIR__ . self::$CredentialsFile.' not found!');
+            throw new Exception\Credentials(self::$CredentialsFile.' not found!');
         }
     }
-
+    
     /**
      * @throws Exception\Credentials
      */


### PR DESCRIPTION
Hey,

This little change allows me to go like this:
```php
PromisePay\Configuration::$CredentialsFile =  APPPATH .'config/promisepay-credentials.xml';
```

Instead of
```php
PromisePay\Configuration::$CredentialsFile =  '/../../../../' . APPPATH .'/config/promisepay-credentials.xml';
```

It should be backwards compatible with the previous way it worked (relative to vendors directory). 