### PR TITLE
Adding User()->getCount()

### DIFF
--- a/lib/TokenRepository.php
+++ b/lib/TokenRepository.php
@@ -22,4 +22,33 @@ class TokenRepository
         
         return $jsonDecodedResponse;
     }
+
+
+    /**
+     * Request Token Auths
+     *
+     * == Example $params ==
+     *
+     * Card Token :
+     * [ 'token_type' => 'card', 'user_id' => $user_id ]
+     *
+     * Approve token :
+     * [ 'token_type' => 4, 'email' => $marketplace_users_email, 'password' => $marketplace_users_password ]
+     *
+     * EUI token :
+     * // Not available yet
+     *
+     * http://reference.promisepay.com/docs/generate-a-card-token
+     *
+     * @since 1.2 As per https://promisepay-api.readme.io/docs/generate-a-card-token
+     * @param  array $params
+     * @return array JSON decoded API response
+     */
+    public static function requestTokenAuths($params)
+    {
+        $response = PromisePay::RestClient('post', 'token_auths/', $params);
+        $jsonDecodedResponse = json_decode($response->raw_body, true);
+
+        return $jsonDecodedResponse;
+    }
 }

--- a/lib/UserRepository.php
+++ b/lib/UserRepository.php
@@ -45,6 +45,14 @@ class UserRepository
         $response = PromisePay::RestClient('post', '/users/' . $id . '/mobile_pin');
         return json_decode($response->raw_body, true);
     }
+    
+    public static function getCount() {
+      $params = ['limit' => 0, 'offset' => 0];
+      $response = PromisePay::RestClient('get', 'users/', $params);
+      $jsonDecodedResponse = json_decode($response->raw_body, true);
+
+      return $jsonDecodedResponse['meta']['total'];
+    }
 
     public static function getListOfItems($id)
     {


### PR DESCRIPTION
Adding a getCount() function for Users.

Currently the ['meta']['total'] information is discarded by the PHP SDK and there's no easy way of knowing the total number of users. This returns just the total.
