### PR TITLE
stop duplicating payload to query string on POST as it is in the body

### DIFF
--- a/lib/PromisePay.php
+++ b/lib/PromisePay.php
@@ -97,7 +97,7 @@ class PromisePay {
         // Httpful only accepts lowercase request methods
         $method = strtolower($method);
         
-        $url = constant(__NAMESPACE__ . '\API_URL') . $entity . '?' . $payload;
+        $url = constant(__NAMESPACE__ . '\API_URL') . $entity;
         
         if (self::$sendAsync) {
             self::$pendingRequests[] = array(
@@ -115,6 +115,7 @@ class PromisePay {
         
         switch ($method) {
             case 'get':
+                $url .= '?' . $payload;
                 $response = \Httpful\Request::get($url)
                 ->timeoutIn($timeout)
                 ->authenticateWith(
@@ -134,6 +135,7 @@ class PromisePay {
                 
                 break;
             case 'delete':
+                $url .= '?' . $payload;
                 $response = \Httpful\Request::delete($url)
                 ->timeoutIn($timeout)
                 ->authenticateWith(

--- a/lib/PromisePay.php
+++ b/lib/PromisePay.php
@@ -115,8 +115,7 @@ class PromisePay {
         
         switch ($method) {
             case 'get':
-                $url .= '?' . $payload;
-                $response = \Httpful\Request::get($url)
+                $response = \Httpful\Request::get($url . '?' . $payload)
                 ->timeoutIn($timeout)
                 ->authenticateWith(
                     constant(__NAMESPACE__ . '\API_LOGIN'),
@@ -135,8 +134,7 @@ class PromisePay {
                 
                 break;
             case 'delete':
-                $url .= '?' . $payload;
-                $response = \Httpful\Request::delete($url)
+                $response = \Httpful\Request::delete($url . '?' . $payload)
                 ->timeoutIn($timeout)
                 ->authenticateWith(
                     constant(__NAMESPACE__ . '\API_LOGIN'),


### PR DESCRIPTION
Having payload added to the query string may result in the server side logging the query string which may contain potential sensitive information.