### PR TITLE
Verify user and URL creation logic

### DIFF
--- a/lib/PromisePay.php
+++ b/lib/PromisePay.php
@@ -97,7 +97,14 @@ class PromisePay {
         // Httpful only accepts lowercase request methods
         $method = strtolower($method);
         
-        $url = constant(__NAMESPACE__ . '\API_URL') . $entity . '?' . $payload;
+		$url = constant(__NAMESPACE__ . '\API_URL') . $entity;
+        if ($payload != '') {
+            if (strpos($url, '?')) {
+                $url .= '&' . $payload;
+            } else {
+                $url .= '?' . $payload;
+            }
+        }
         
         if (self::$sendAsync) {
             self::$pendingRequests[] = array(

--- a/lib/User.php
+++ b/lib/User.php
@@ -81,4 +81,10 @@ class User {
         
         return $result['users'];
     }
+    
+    public function verifyUser($id) {
+        PromisePay::RestClient('patch', 'users/' . $id . "?type=identity_verified");
+
+        return PromisePay::getDecodedResponse('users');
+    }
 }


### PR DESCRIPTION
Added a "Verify User" call to the User.php file.

This also resulted in unexpected behaviour when calling Assembly Payments. 

This led to the PromisePay.php file, RestClient call, having its $url creation logic updated to ensure the final URL does not include two question marks. If $params are added, they are correctly appended to a question mark-including URL with an ampersand.